### PR TITLE
bag of words and ngram model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Word2vec papers &amp; tutorial
 7. Hierarchical Probabilistic Neural Network Language Model - http://www.iro.umontreal.ca/~lisa/pointeurs/hierarchical-nnlm-aistats05.pdf
 
 8. A Scalable Hierarchical Distributed Language Model - https://pdfs.semanticscholar.org/1005/645c05585c2042e3410daeed638b55e2474d.pdf
+
+9. bag of words and ngram model - https://en.wikipedia.org/wiki/Bag-of-words_model


### PR DESCRIPTION
"Conceptually, we can view bag-of-word model as a special case of the n-gram model, with n=1. See language model for a more detailed discussion."